### PR TITLE
Export Imago class

### DIFF
--- a/src/imago.js
+++ b/src/imago.js
@@ -6,7 +6,7 @@
   else if (typeof exports !== 'undefined')
     exports.Imago = Imago;
   else
-    window.Imago = Imago;
+    window.Imago = new Imago();
 }(function() {
   'use strict';
 

--- a/src/imago.js
+++ b/src/imago.js
@@ -2,11 +2,11 @@
   'use strict';
 
   if (typeof define === 'function' && define.amd)
-    define('imago-js', [], new Imago());
+    define('imago-js', [], Imago);
   else if (typeof exports !== 'undefined')
-    exports.Imago = new Imago();
+    exports.Imago = Imago;
   else
-    window.Imago = new Imago();
+    window.Imago = Imago;
 }(function() {
   'use strict';
 

--- a/test/imago.js
+++ b/test/imago.js
@@ -3,7 +3,7 @@ var image,
     imageWithFigure,
     figureWithImage;
 
-describe('imago.js', function(argument) {
+describe('imago.js', function() {
   beforeEach(function() {
     jasmine.getFixtures().fixturesPath = '../../base/test';
     jasmine.getStyleFixtures().fixturesPath = '../../base/test';
@@ -42,8 +42,8 @@ describe('imago.js', function(argument) {
 
     it('wrap image with a figure', function(done) {
       expect(image.parentElement.id).toEqual('jasmine-fixtures');
-      new Imago(image);    
-      
+      new Imago(image);
+
       setTimeout(function() {
         expect(image.parentElement.nodeName.toLowerCase()).toEqual('figure');
         done();
@@ -67,7 +67,7 @@ describe('imago.js', function(argument) {
       expect(image).not.toHaveAttr('data-height');
       expect(image).not.toHaveAttr('data-top');
       expect(image).not.toHaveAttr('data-left');
-      
+
       new Imago(image);
 
       setTimeout(function() {
@@ -88,7 +88,7 @@ describe('imago.js', function(argument) {
       expect(imageWithAttributes).toHaveAttr('data-height', '424');
       expect(imageWithAttributes).toHaveAttr('data-top', '0');
       expect(imageWithAttributes).toHaveAttr('data-left', '0');
-      
+
       new Imago(imageWithAttributes);
 
       setTimeout(function() {


### PR DESCRIPTION
Previous exports exported initialized instance and prevented import Imago via npm.
When you try `import Imago from 'imago-js'` it always will throw this exception: https://github.com/evandroeisinger/imago.js/blob/master/src/imago.js#L143 because it call `new Imago()` on import.
I don't know what to fix in tests, because current tests is not working at all. But I tested this in my repo with Babel and import is working.

BTW. I think to add some build tool like webpack and split source to separate files. What you think?
